### PR TITLE
Increase row group size + minor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Layercake is a set of thematic extracts of [OpenStreetMap](https://www.openstreetmap.org/about) data in cloud-native file formats.
 
-OpenStreetMap’s native file format is OSM PBF, but this 80GB ‘planet file’ is unwieldly and not supported by all GIS software. Layercake provides OSM data separated into thematic layers (buildings, transportation, etc) and converted to cloud-native file formats like GeoParquet that are easy to use with software from DuckDB to QGIS.
+OpenStreetMap’s native file format is OSM PBF, but this 80GB ‘planet file’ is unwieldy and not supported by all GIS software. Layercake provides OSM data separated into thematic layers (buildings, transportation, etc) and converted to cloud-native file formats like GeoParquet that are easy to use with software from DuckDB to QGIS.
 
 This repository contains the code that is used to generate the extracts, which are hosted by [OpenStreetMap US](https://openstreetmap.us/) at `data.openstreetmap.us`. [Instructions on how to access the data](https://openstreetmap.us/our-work/layercake/) are available on the OpenStreetMap US website.
 

--- a/process_osm.py
+++ b/process_osm.py
@@ -14,11 +14,17 @@ LAYERS = {
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Process OSM data into multiple GeoParquet files")
+    parser = argparse.ArgumentParser(
+        description="Process OSM data into multiple GeoParquet files"
+    )
     parser.add_argument("osm_file", help="Input OSM PBF file")
-    parser.add_argument("output_dir", help="Directory to write output GeoParquet files to")
     parser.add_argument(
-        "--osmium-idx", default="flex_mem", help="Osmium index type to use for node locations"
+        "output_dir", help="Directory to write output GeoParquet files to"
+    )
+    parser.add_argument(
+        "--osmium-idx",
+        default="flex_mem",
+        help="Osmium index type to use for node locations (see https://osmcode.org/osmium-concepts/)",
     )
 
     for layer_name in LAYERS.keys():
@@ -30,7 +36,9 @@ def main():
 
     args = parser.parse_args()
 
-    enabled_layers = {layer_name for layer_name in LAYERS.keys() if getattr(args, layer_name)}
+    enabled_layers = {
+        layer_name for layer_name in LAYERS.keys() if getattr(args, layer_name)
+    }
     if not enabled_layers:
         # if no layers are provided as CLI arguments, default to building them all
         enabled_layers = set(LAYERS.keys())

--- a/src/geoparquet.py
+++ b/src/geoparquet.py
@@ -1,4 +1,3 @@
-import sys
 import json
 import binascii
 
@@ -102,7 +101,9 @@ class GeoParquetWriter(osmium.SimpleHandler):
 
         bbox = dict(zip(["xmin", "ymin", "xmax", "ymax"], shapely.bounds(geom)))
 
-        self.chunk.append({"type": type, "id": id, "tags": attrs, "bbox": bbox, "geometry": wkb})
+        self.chunk.append(
+            {"type": type, "id": id, "tags": attrs, "bbox": bbox, "geometry": wkb}
+        )
 
         if len(self.chunk) >= 1000:
             self.flush()

--- a/src/geoparquet.py
+++ b/src/geoparquet.py
@@ -16,17 +16,19 @@ class GeoParquetWriter(osmium.SimpleHandler):
     their own tag sets and filtering logic.
     """
 
-    def __init__(self, filename, tags, schema_metadata=None):
+    def __init__(self, filename, tags, schema_metadata=None, row_group_size = 100_000):
         """Initialize the writer.
 
         Args:
             filename: Path to the output Parquet file
             tags: List of OSM tags to include in the output
             schema_metadata: Optional additional metadata to include in the schema
+            row_group_size: The number of rows to write per group
         """
         super().__init__()
         self.filename = filename
         self.tags = tags
+        self.row_group_size = row_group_size
 
         # Create the schema
         bbox_schema = pyarrow.struct(
@@ -105,7 +107,7 @@ class GeoParquetWriter(osmium.SimpleHandler):
             {"type": type, "id": id, "tags": attrs, "bbox": bbox, "geometry": wkb}
         )
 
-        if len(self.chunk) >= 1000:
+        if len(self.chunk) >= self.row_group_size:
             self.flush()
 
     def flush(self):


### PR DESCRIPTION
The main thing this PR does is increase the row group size default from 1000 to 100,000. There is always nuance to a decision like this, but I am pretty confident in saying that a row group size of 1,000 is way too small for most layers. Here are the things to weigh:

* How you're querying the data (obj store, fast local SSDs, etc.)
* The nature of the dataset. Perhaps something like boundaries would benefit (in terms of predicate pushdown selectivity) by a smaller row group count, whereas addresses certainly benefit from a larger row group count (it should probably be closer to a million).

I've left it configurable so that writers can override as needed.

For maximum effect, this should be paired with a spatial sort as discussed in #2.