### PR TITLE
Add osmium filters based on what the active writers are interested in

### DIFF
--- a/src/buildings.py
+++ b/src/buildings.py
@@ -35,6 +35,8 @@ class BuildingsWriter(GeoParquetWriter):
         "wheelchair",
     ]
 
+    FILTERS = {"building"}
+
     def __init__(self, filename):
         super().__init__(filename, self.TAGS)
 

--- a/src/geoparquet.py
+++ b/src/geoparquet.py
@@ -1,5 +1,6 @@
 import json
 import binascii
+import typing
 
 import osmium
 import pyarrow
@@ -16,7 +17,15 @@ class GeoParquetWriter(osmium.SimpleHandler):
     their own tag sets and filtering logic.
     """
 
-    def __init__(self, filename, tags, schema_metadata=None, row_group_size = 100_000):
+    # A set of tags that the writer is interested in.
+    # Subclasses MUST add these (or you'll trigger a runtime assertion).
+    # Filters are OR'd together across a processing run.
+    # Objects will match if they contain a tag that ANY writer is interested in.
+    # Writers will receive objects matching the aggregate filter,
+    # so handlers should implement their own checks.
+    FILTERS: typing.Set[str] = set()
+
+    def __init__(self, filename, tags, schema_metadata=None, row_group_size=100_000):
         """Initialize the writer.
 
         Args:

--- a/src/highways.py
+++ b/src/highways.py
@@ -39,6 +39,8 @@ class HighwaysWriter(GeoParquetWriter):
         "toll",
     ]
 
+    FILTERS = {"highway"}
+
     def __init__(self, filename):
         super().__init__(filename, self.TAGS)
 


### PR DESCRIPTION
Pretty self-explanatory. This adds tag filtering at the osmium level. Currently it's a simple "is this key present at all" test, but I could envision this getting slightly more sophisticated in the future.

At a high level, each writer is now required to state which tags it is interested in objects having. The set of _all_ tags is coalesced, and if _any_ of those tags matches, it's passed down to the writers.

As a side note, there are multiple ways of filtering with PyOsmium; we're currently exclusively using C++-level filters, which keep things efficient. Arbitrary Python filters are also supported, but the perf is usually not great for these.

I did some informal benchmarks on the DACH area extract (~6GB) on my laptop (M1 Max with 32GB RAM), and the import for my own (to be PR'd eventually) boundaries theme was **consistently ~40% faster** with the filtering in place. Obviously the effect will degrade slightly if we have a dozen layers, but I expect this to still provide a non-trivial boost.