### PR TITLE
Enable writers to process relations

### DIFF
--- a/process_osm.py
+++ b/process_osm.py
@@ -70,6 +70,11 @@ def main():
                 if hasattr(writer, "way"):
                     writer.way(o)
 
+        def relation(self, o):
+            for writer in self.writers:
+                if hasattr(writer, "relation"):
+                    writer.relation(o)
+
         def area(self, o):
             for writer in self.writers:
                 if hasattr(writer, "area"):


### PR DESCRIPTION
Short and sweet: this just enables writers to process relations; the proxy wasn't passing these on.

(Relations in the current writers are exclusively area-based, so the area handler works for those.... for non-area relations though, like `associatedStreet` and other oddities that some thematic layers would really benefit from processing, you need to do it the lower-level way like this.)