### PR TITLE
Switch to zstd compression

### DIFF
--- a/src/geoparquet.py
+++ b/src/geoparquet.py
@@ -86,7 +86,7 @@ class GeoParquetWriter(osmium.SimpleHandler):
             metadata=base_metadata,
         )
 
-        self.writer = pyarrow.parquet.ParquetWriter(filename, self.schema)
+        self.writer = pyarrow.parquet.ParquetWriter(filename, self.schema, compression='zstd')
         self.chunk = []
         self.wkbfactory = osmium.geom.WKBFactory()
 


### PR DESCRIPTION
Pretty straightforward. It's perfectly suitable for high throughput use cases (see the motivation for creating it at Facebook, widespread use in the ZFS filesystem, etc.). For Layercake specifically, we're obviously not compression-bound for writing, and for consumption, this conserves both disk space and bandwidth :)