### PR TITLE
Spatially sort output parquet files by postprocessing with DuckDB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM debian:12
 
-RUN apt update && apt install -y python3 python3-pip python3-venv python-is-python3
+RUN apt update && apt install -y curl python3 python3-pip python3-venv python-is-python3
+RUN curl https://install.duckdb.org | sh
+RUN /root/.duckdb/cli/latest/duckdb -c 'INSTALL SPATIAL'
+
 COPY . /run/layercake
 WORKDIR /run/layercake
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+# add duckdb cli to path
+export PATH='/root/.duckdb/cli/latest':$PATH
+
+# activate python virtual environment
 . venv/bin/activate
 
 python process_osm.py "$@"
+
+for input_file in out/*.parquet; do
+  output_file="out/$(basename -s .parquet $input_file)-optimized.parquet"
+  ./postprocess.sh $input_file $output_file
+  mv $output_file $input_file
+done

--- a/postprocess.sh
+++ b/postprocess.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+echo $@
+
+duckdb << EOF
+LOAD SPATIAL;
+
+COPY (
+    SELECT *
+    FROM '$1'
+    ORDER BY ST_Hilbert(
+        geometry,
+        (
+            SELECT ST_Extent(ST_Extent_Agg(geometry))
+            FROM '$1'
+        )
+    )
+)
+TO '$2' (
+    FORMAT PARQUET,
+    COMPRESSION ZSTD
+    -- TBD: Partitioning; row group size by bytes?
+);
+EOF


### PR DESCRIPTION
Fixes #2. Now you can run queries like this:

```
$ duckdb
D load spatial;
D .timer on
D copy (
        from 'https://data.openstreetmap.us/layercake/buildings.parquet'
        select type as osm_type, id as osm_id, tags.*, geometry
        where try_cast(tags."building:levels" as int) > 5
          and bbox.xmin > -109.05
          and bbox.ymin > 36.99
          and bbox.xmax < -102.04
          and bbox.ymax < 41.00
      ) to 'colorado_tall_buildings.geojson' with (format GDAL, driver 'GeoJSON');
100% ▕████████████████████████████████████████████████████████████▏
Run Time (s): real 211.327 user 1.862303 sys 1.013529
D ^D
$ ls -lh colorado_tall_buildings.geojson
-rw-r--r--  1 jake staff 1.1M Jul 15 10:42 colorado_tall_buildings.geojson
```

Previously this would have taken an impossibly long time; now it only takes a couple minutes. I wonder if it can be sped up further?

Anyway, I tested this code in the most recent build, so the results are already up on `https://data.openstreetmap.us/layercake/` if you'd like to play around with them.