### PR TITLE
Increase compression level

### DIFF
--- a/postprocess.sh
+++ b/postprocess.sh
@@ -18,7 +18,8 @@ COPY (
 )
 TO '$2' (
     FORMAT PARQUET,
-    COMPRESSION ZSTD
+    COMPRESSION ZSTD,
+    COMPRESSION_LEVEL 10
     -- TBD: Partitioning; row group size by bytes?
 );
 EOF


### PR DESCRIPTION
Anecdotally on my laptop, setting compression to level 10 increases the DuckDB script running time by around 20%, but it comes with significant space savings. Here are the figures for a test using a boundaries dataset I have locally.

Unoptimized: 4.64GB
Optimized using the current DuckDB SQL (default compression level): 2.83GB
Optimized using COMPRESSION_LEVEL 10: 1.84GB

That's a pretty significant savings, given that the dataset's weight is mostly coming from complex geometries!

I experimented with some other levels as @jtbaker suggested [via this guide](https://github.com/opengeospatial/geoparquet/blob/main/format-specs/distributing-geoparquet.md#duckdb). For the boundaries dataset, I found that the recommended level of 15 did not yield any further space savings (it trimmed the final size down to 1.81GB), at the expense of taking several _times_ longer to run than level 10, and consuming more memory for longer periods.

TL;DR I think level 10 is probably a good balance for now.