### PR TITLE
Add a places layer

### DIFF
--- a/process_osm.py
+++ b/process_osm.py
@@ -6,10 +6,12 @@ import osmium
 
 from src.highways import HighwaysWriter
 from src.buildings import BuildingsWriter
+from src.places import PlacesWriter
 
 LAYERS = {
     "highways": HighwaysWriter,
     "buildings": BuildingsWriter,
+    "places": PlacesWriter,
 }
 
 

--- a/process_osm.py
+++ b/process_osm.py
@@ -6,12 +6,12 @@ import osmium
 
 from src.highways import HighwaysWriter
 from src.buildings import BuildingsWriter
-from src.places import PlacesWriter
+from src.settlements import SettlementsWriter
 
 LAYERS = {
     "highways": HighwaysWriter,
     "buildings": BuildingsWriter,
-    "places": PlacesWriter,
+    "settlements": SettlementsWriter,
 }
 
 

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -1,0 +1,7 @@
+def tags_with_prefix(prefix, tags):
+    """
+    Returns a dict of all tags with the given prefix string; keys in the
+    dict will have the prefix dropped.
+    """
+    prefix_len = len(prefix)
+    return {k[prefix_len:]: v for (k, v) in tags if k.startswith(prefix)}

--- a/src/places.py
+++ b/src/places.py
@@ -1,0 +1,101 @@
+import sys
+import pyarrow
+import shapely.wkb
+
+from .geoparquet import GeoParquetWriter
+
+
+class PlacesWriter(GeoParquetWriter):
+    """
+    The places layer contains point geometries representing named places
+    (cities, towns, neighborhoods, etc) from OSM - anything tagged place=*
+    that has a name.
+
+    Most place features are mapped as nodes, but some are mapped as areas
+    (typically neighborhoods, islands, etc). In these cases we include the
+    area's centroid in the output dataset.
+    """
+
+    COLUMNS = [
+        ("place", pyarrow.string()),
+        ("name", pyarrow.string()),
+        ("names", pyarrow.map_(pyarrow.string(), pyarrow.string())),
+        ("alt_name", pyarrow.string()),
+        ("alt_names", pyarrow.map_(pyarrow.string(), pyarrow.string())),
+        ("official_name", pyarrow.string()),
+        ("official_names", pyarrow.map_(pyarrow.string(), pyarrow.string())),
+        ("wikidata", pyarrow.string()),
+        ("wikipedia", pyarrow.string()),
+        ("population", pyarrow.uint32()),
+    ]
+
+    FILTERS = {"place"}
+
+    def node(self, o):
+        if "place" not in o.tags or "name" not in o.tags:
+            return
+
+        try:
+            self.append("node", o.id, self.columns(o.tags), self.wkbfactory.create_point(o))
+        except RuntimeError as e:
+            print(e, file=sys.stderr)
+
+    def area(self, o):
+        if "place" not in o.tags or "name" not in o.tags:
+            return
+
+        if not o.from_way() and "boundary" in o.tags:
+            # Administrativie boundary relations often have a 'label' member,
+            # which is itself a place=* node. To avoid creating multiple rows
+            # for a given place (city, town, etc), we skip boundary relations
+            # that are tagged place=*. It would be better to check if the
+            # relation actually has a member with the 'label' role, but Osmium
+            # doesn't let us access members on Area instances, so we're forced
+            # to just assume.
+            return
+
+        try:
+            # The "places" layer contains only POINT geometries; for areas
+            # tagged place=* we use the centroid.
+            polygon_wkb = self.wkbfactory.create_multipolygon(o)
+            polygon = shapely.wkb.loads(polygon_wkb, hex=True)
+            centroid = polygon.centroid
+            centroid_wkb = shapely.wkb.dumps(centroid).hex()
+
+            self.append(
+                "way" if o.from_way() else "relation",
+                o.orig_id(),
+                self.columns(o.tags),
+                centroid_wkb,
+            )
+        except RuntimeError as e:
+            print(e, file=sys.stderr)
+
+    def columns(self, tags):
+        return {key: column(key, tags) for (key, _) in self.COLUMNS}
+
+
+def column(column_name, tags):
+    """
+    Using the tags for a given OSM element, return the appropriate value
+    for the specified column in the output dataset.
+    """
+    match column_name:
+        case "population":
+            try:
+                return int(tags.get("population"))
+            except (TypeError, ValueError):
+                return None
+        case "names" | "alt_names" | "official_names":
+            return tags_with_prefix(f"{column_name[:-1]}:", tags)
+        case _:
+            return tags.get(column_name)
+
+
+def tags_with_prefix(prefix, tags):
+    """
+    Returns a dict of all tags with the given prefix string; keys in the
+    dict will have the prefix dropped.
+    """
+    prefix_len = len(prefix)
+    return {k[prefix_len:]: v for (k, v) in tags if k.startswith(prefix)}

--- a/src/places.py
+++ b/src/places.py
@@ -1,19 +1,14 @@
 import sys
 import pyarrow
-import shapely.wkb
 
 from .geoparquet import GeoParquetWriter
 
 
 class PlacesWriter(GeoParquetWriter):
     """
-    The places layer contains point geometries representing named places
-    (cities, towns, neighborhoods, etc) from OSM - anything tagged place=*
-    that has a name.
-
-    Most place features are mapped as nodes, but some are mapped as areas
-    (typically neighborhoods, islands, etc). In these cases we include the
-    area's centroid in the output dataset.
+    The places layer contains point geometries representing named human
+    settlements (cities, towns, villages) and parts of settlements (boroughs,
+    qaurters, neighborhoods) from OSM.
     """
 
     COLUMNS = [
@@ -31,42 +26,30 @@ class PlacesWriter(GeoParquetWriter):
 
     FILTERS = {"place"}
 
+    PLACE_TYPES = {
+        # place=* values from OSM that represent human settlements
+        "city",
+        "town",
+        "village",
+        "hamlet",
+        "isolated_dwelling",
+        "farm",
+        "allotments"
+        # ...and parts of settlements:
+        "borough",
+        "suburb",
+        "quarter",
+        "neighborhood",
+        "city_block",
+    }
+
     def node(self, o):
-        if "place" not in o.tags or "name" not in o.tags:
+        if o.tags.get("place") not in self.PLACE_TYPES or "name" not in o.tags:
             return
 
         try:
-            self.append("node", o.id, self.columns(o.tags), self.wkbfactory.create_point(o))
-        except RuntimeError as e:
-            print(e, file=sys.stderr)
-
-    def area(self, o):
-        if "place" not in o.tags or "name" not in o.tags:
-            return
-
-        if not o.from_way() and "boundary" in o.tags:
-            # Administrativie boundary relations often have a 'label' member,
-            # which is itself a place=* node. To avoid creating multiple rows
-            # for a given place (city, town, etc), we skip boundary relations
-            # that are tagged place=*. It would be better to check if the
-            # relation actually has a member with the 'label' role, but Osmium
-            # doesn't let us access members on Area instances, so we're forced
-            # to just assume.
-            return
-
-        try:
-            # The "places" layer contains only POINT geometries; for areas
-            # tagged place=* we use the centroid.
-            polygon_wkb = self.wkbfactory.create_multipolygon(o)
-            polygon = shapely.wkb.loads(polygon_wkb, hex=True)
-            centroid = polygon.centroid
-            centroid_wkb = shapely.wkb.dumps(centroid).hex()
-
             self.append(
-                "way" if o.from_way() else "relation",
-                o.orig_id(),
-                self.columns(o.tags),
-                centroid_wkb,
+                "node", o.id, self.columns(o.tags), self.wkbfactory.create_point(o)
             )
         except RuntimeError as e:
             print(e, file=sys.stderr)

--- a/src/settlements.py
+++ b/src/settlements.py
@@ -4,9 +4,9 @@ import pyarrow
 from .geoparquet import GeoParquetWriter
 
 
-class PlacesWriter(GeoParquetWriter):
+class SettlementsWriter(GeoParquetWriter):
     """
-    The places layer contains point geometries representing named human
+    The settlements layer contains point geometries representing named human
     settlements (cities, towns, villages) and parts of settlements (boroughs,
     qaurters, neighborhoods) from OSM.
     """

--- a/src/settlements.py
+++ b/src/settlements.py
@@ -2,6 +2,7 @@ import sys
 import pyarrow
 
 from .geoparquet import GeoParquetWriter
+from .helpers import tags_with_prefix
 
 
 class SettlementsWriter(GeoParquetWriter):
@@ -73,12 +74,3 @@ def column(column_name, tags):
             return tags_with_prefix(f"{column_name[:-1]}:", tags)
         case _:
             return tags.get(column_name)
-
-
-def tags_with_prefix(prefix, tags):
-    """
-    Returns a dict of all tags with the given prefix string; keys in the
-    dict will have the prefix dropped.
-    """
-    prefix_len = len(prefix)
-    return {k[prefix_len:]: v for (k, v) in tags if k.startswith(prefix)}

--- a/src/settlements.py
+++ b/src/settlements.py
@@ -21,7 +21,7 @@ class SettlementsWriter(GeoParquetWriter):
         ("official_names", pyarrow.map_(pyarrow.string(), pyarrow.string())),
         ("wikidata", pyarrow.string()),
         ("wikipedia", pyarrow.string()),
-        ("population", pyarrow.uint32()),
+        ("population", pyarrow.uint64()),
     ]
 
     FILTERS = {"place"}


### PR DESCRIPTION
This PR adds a "Places" layer containing OSM features tagged `place=*`, which represent countries, states, provinces, cities, towns, villages, neighborhoods, etc. Features in this layer are all Point geometries: they represent the approximate center of the feature.

I added this layer partly because it's useful to me, but also because it's simple and therefore a good testbed for two new schema ideas:
- The `population` column is an integer. This is the first foray into parsing OSM's string-valued tags into other data types.
- The `name` column contains the value of that tag in OSM, which (usually) represents the name in the primary local language. But this layer also contains a `names` column which is a `Map<str, str>` which contains all of the OSM tags whose keys start with `name:`, e.g. `name:left`, `name:fr`, and even `name:etymology:wikidata`. Keys in the map are the tag key with the `name:` prefix dropped, and values are the OSM tag value. So for example `tags.names.es` contains the value of `name:es` (the Spanish language name), if available. I also added `alt_names` and `official_names` maps to complement the `alt_name` and `official_name` columns.