### PR TITLE
Batch columnar parquet writes with vectorized bbox computation

### DIFF
--- a/src/geoparquet.py
+++ b/src/geoparquet.py
@@ -6,7 +6,7 @@ import osmium
 import pyarrow
 import pyarrow.parquet
 import shapely
-import shapely.wkb
+
 
 
 class GeoParquetWriter(osmium.SimpleHandler):
@@ -101,12 +101,20 @@ class GeoParquetWriter(osmium.SimpleHandler):
         self.writer = pyarrow.parquet.ParquetWriter(
             filename, self.schema, compression="zstd"
         )
-        self.chunk = []
         self.wkbfactory = osmium.geom.WKBFactory()
+        self._tag_names = [key for key, _ in self.COLUMNS]
+        self._reset_buffers()
+
+    def _reset_buffers(self):
+        self._col_type = []
+        self._col_id = []
+        self._col_tags = []
+        self._col_wkb = []
+        self._count = 0
 
     def finish(self):
         """Finish writing the file."""
-        if self.chunk:
+        if self._count:
             self.flush()
         self.writer.close()
 
@@ -119,20 +127,53 @@ class GeoParquetWriter(osmium.SimpleHandler):
             attrs: additional columns to write; must match COLUMNS schema
             wkb_hex: WKB geometry in hex format
         """
-        geom = shapely.wkb.loads(wkb_hex, hex=True)
-        wkb = binascii.unhexlify(wkb_hex)
+        self._col_type.append(type)
+        self._col_id.append(id)
+        self._col_tags.append(attrs)
+        self._col_wkb.append(binascii.unhexlify(wkb_hex))
 
-        bbox = dict(zip(["xmin", "ymin", "xmax", "ymax"], shapely.bounds(geom)))
-
-        self.chunk.append(
-            {"type": type, "id": id, "tags": attrs, "bbox": bbox, "geometry": wkb}
-        )
-
-        if len(self.chunk) >= self.row_group_size:
+        self._count += 1
+        if self._count >= self.row_group_size:
             self.flush()
 
     def flush(self):
-        """Write the current chunk to the Parquet file."""
-        table = pyarrow.Table.from_pylist(self.chunk, schema=self.schema)
+        """Write the current chunk to the Parquet file.
+
+        Builds the pyarrow table from columnar buffers and computes
+        bounding boxes in bulk.
+        """
+        # Bbox via vectorized shapely
+        geoms = shapely.from_wkb(self._col_wkb)
+        bounds = shapely.bounds(geoms)
+
+        bbox_array = pyarrow.StructArray.from_arrays(
+            [
+                pyarrow.array(bounds[:, 0], type=pyarrow.float32()),
+                pyarrow.array(bounds[:, 1], type=pyarrow.float32()),
+                pyarrow.array(bounds[:, 2], type=pyarrow.float32()),
+                pyarrow.array(bounds[:, 3], type=pyarrow.float32()),
+            ],
+            names=["xmin", "ymin", "xmax", "ymax"],
+        )
+
+        # Build per-column tag arrays from the collected dicts
+        tag_arrays = []
+        for key, pa_type in self.COLUMNS:
+            tag_arrays.append(
+                pyarrow.array([t.get(key) for t in self._col_tags], type=pa_type)
+            )
+        tags_array = pyarrow.StructArray.from_arrays(tag_arrays, names=self._tag_names)
+
+        table = pyarrow.Table.from_arrays(
+            [
+                pyarrow.array(self._col_type, type=pyarrow.string()),
+                pyarrow.array(self._col_id, type=pyarrow.int64()),
+                tags_array,
+                bbox_array,
+                pyarrow.array(self._col_wkb, type=pyarrow.binary()),
+            ],
+            schema=self.schema,
+        )
+
         self.writer.write_table(table)
-        self.chunk = []
+        self._reset_buffers()


### PR DESCRIPTION
- Replace per-row shapely.wkb.loads + shapely.bounds with batched flush: append() stores to flat lists, flush() does vectorized shapely.from_wkb/bounds
- Build pyarrow Table from columnar arrays instead of from_pylist (dicts)

This particular recorded run saw a 30% decrease in total time taken and a 15% increase in peak RSS usage for an Indian extract.. Haven't done a more systematic benchmark.. but have seen somewhere between 20 to 30 % decrease in time taken over multiple runs. 

Input file from geofabrik: 
`ls -lh india-latest.osm.pbf `
```
-rw-r--r--  1 ram  staff   1.5G Mar 15 05:04 india-latest.osm.pbf
```

Comamnd ran:
```
 /usr/bin/time -l uv run --with-requirements requirements.txt process_osm.py india-latest.osm.pbf out 2>&1 | grep -v invalid
```

Before:
```
      999.60 real       850.08 user        89.24 sys
          1930018816  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
            19774772  page reclaims
                3616  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                  57  messages sent
                  77  messages received
                   1  signals received
              503877  voluntary context switches
             1084430  involuntary context switches
           318214309  instructions retired
           163328276  cycles elapsed
            28460672  peak memory footprint
```

After:
```
      698.45 real       619.74 user        67.53 sys
          2199617536  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
            14920853  page reclaims
                4224  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                  56  messages sent
                  76  messages received
                   1  signals received
              319846  voluntary context switches
              885358  involuntary context switches
           330623619  instructions retired
           165216952  cycles elapsed
            27428416  peak memory footprint
```

Relevant Hardware info of the machine the tests were run on:

Command: `system_profiler SPHardwareDataType`

Relevant response:
```
Hardware:

    Hardware Overview:

      Model Name: MacBook Pro
      Model Identifier: MacBookPro17,1
      Model Number: MYD82HN/A
      Chip: Apple M1
      Total Number of Cores: 8 (4 performance and 4 efficiency)
      Memory: 8 GB
      System Firmware Version: 10151.140.19
      OS Loader Version: 10151.140.19
```

`ls -l out/` both before and after

```
total 7387328
-rw-r--r--  1 ram  staff   181490578 Mar 16 22:03 boundaries.parquet
-rw-r--r--  1 ram  staff  1384825648 Mar 16 22:03 buildings.parquet
-rw-r--r--  1 ram  staff  2193114843 Mar 16 22:03 highways.parquet
-rw-r--r--  1 ram  staff          61 Mar 16 22:03 metadata.json
-rw-r--r--  1 ram  staff     7703695 Mar 16 22:03 parks.parquet
-rw-r--r--  1 ram  staff    15163388 Mar 16 22:03 settlements.parquet
```

