### PR TITLE
Improve entrypoint.sh script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,12 +2,17 @@
 
 set -eu
 
+if [[ $# -lt 2 ]]; then
+    echo "Error: Expected ./entrypoint.sh <input_file> <output_dir>"
+    exit 1
+fi
+
 echo "Extracting feature layers from $1"
 ./process.sh "$@"
 
-for input_file in out/*.parquet; do
+for input_file in "$2"/*.parquet; do
   echo "Sorting and compressing $input_file"
-  output_file="out/$(basename -s .parquet $input_file)-optimized.parquet"
+  output_file="$2/$(basename -s .parquet $input_file)-optimized.parquet"
   ./postprocess.sh $input_file $output_file
   mv $output_file $input_file
 done

--- a/process.sh
+++ b/process.sh
@@ -15,6 +15,11 @@
 
 set -eu
 
+if [[ $# -lt 2 ]]; then
+    echo "Error: Expected ./process.sh <input_file> <output_dir> ..."
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 INPUT="$1"


### PR DESCRIPTION
It seems like entrypoint.sh may be out of date, since the process.sh seems to take two arguments (the output_dir).
This adds the missing parameter.