### PR TITLE
Add timestamp and version metadata columns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.23
 
 RUN apk add curl libosmium g++ make cmake zlib-dev expat-dev bzip2-dev lz4-dev
 
-ENV DUCKDB_VERSION 1.5.1
+ENV DUCKDB_VERSION 1.5.5
 RUN ARCH=$(uname -m) && \
     case "$ARCH" in \
         x86_64)  DIST="linux-amd64-musl" ;; \

--- a/sql/addresses.sql
+++ b/sql/addresses.sql
@@ -1,6 +1,6 @@
 COPY (
   WITH raw AS (
-    SELECT type, id, tags, ST_PointOnSurface(geometry) AS geometry
+    SELECT type, id, tags, version, timestamp, ST_PointOnSurface(geometry) AS geometry
     FROM '{{INPUT}}'
     WHERE (kind = 'node' OR kind = 'area')
       AND (
@@ -44,6 +44,8 @@ COPY (
     tags['addr:country']             AS "addr:country",
     -- Full, unstructured address; not machine-readable but maybe useful
     tags['addr:full']                AS "addr:full",
+    version,
+    timestamp,
     {
       xmin: ST_XMin(geometry)::FLOAT,
       ymin: ST_YMin(geometry)::FLOAT,

--- a/sql/boundaries.sql
+++ b/sql/boundaries.sql
@@ -1,6 +1,6 @@
 COPY (
   WITH raw AS (
-    SELECT type, id, tags, geometry
+    SELECT type, id, tags, version, timestamp, geometry
     FROM '{{INPUT}}'
     WHERE kind = 'area'
       AND tags['boundary'] IN ('administrative', 'aboriginal_lands', 'maritime', 'disputed', 'place')
@@ -28,6 +28,8 @@ COPY (
     split_multi(tags['claimed_by'])          AS claimed_by,
     split_multi(tags['controlled_by'])       AS controlled_by,
     split_multi(tags['recognized_by'])       AS recognized_by,
+    version,
+    timestamp,
     {
       xmin: ST_XMin(geometry)::FLOAT,
       ymin: ST_YMin(geometry)::FLOAT,

--- a/sql/buildings.sql
+++ b/sql/buildings.sql
@@ -1,6 +1,6 @@
 COPY (
   WITH raw AS (
-    SELECT type, id, tags, geometry
+    SELECT type, id, tags, version, timestamp, geometry
     FROM '{{INPUT}}'
     WHERE kind = 'area'
       AND tags['building'] IS NOT NULL
@@ -29,6 +29,8 @@ COPY (
     tags['start_date']          AS start_date,
     tags['access']              AS access,
     tags['wheelchair']          AS wheelchair,
+    version,
+    timestamp,
     {
       xmin: ST_XMin(geometry)::FLOAT,
       ymin: ST_YMin(geometry)::FLOAT,

--- a/sql/highways.sql
+++ b/sql/highways.sql
@@ -1,6 +1,6 @@
 COPY (
   WITH raw AS (
-    SELECT type, id, tags, geometry
+    SELECT type, id, tags, version, timestamp, geometry
     FROM '{{INPUT}}'
     WHERE tags['highway'] IS NOT NULL
       AND (
@@ -44,6 +44,8 @@ COPY (
     tags['motorcycle']      AS motorcycle,
     tags['oneway']          AS oneway,
     tags['toll']            AS toll,
+    version,
+    timestamp,
     {
       xmin: ST_XMin(geometry)::FLOAT,
       ymin: ST_YMin(geometry)::FLOAT,

--- a/sql/parks.sql
+++ b/sql/parks.sql
@@ -1,6 +1,6 @@
 COPY (
   WITH raw AS (
-    SELECT type, id, tags, geometry
+    SELECT type, id, tags, version, timestamp, geometry
     FROM '{{INPUT}}'
     WHERE (kind = 'node' OR kind = 'area')
       AND (
@@ -34,6 +34,8 @@ COPY (
     tags['website']                             AS website,
     tags['wikidata']                            AS wikidata,
     tags['wikipedia']                           AS wikipedia,
+    version,
+    timestamp,
     {
       xmin: ST_XMin(geometry)::FLOAT,
       ymin: ST_YMin(geometry)::FLOAT,

--- a/sql/pois.sql
+++ b/sql/pois.sql
@@ -1,6 +1,6 @@
 COPY (
   WITH raw AS (
-    SELECT type, id, tags, geometry
+    SELECT type, id, tags, version, timestamp, geometry
     FROM '{{INPUT}}'
     WHERE (kind = 'node' OR kind = 'area')
       AND (
@@ -83,6 +83,8 @@ COPY (
     tags['source']                           AS source,
     tags['sport']                            AS sport,
     tags['wheelchair']                       AS wheelchair,
+    version,
+    timestamp,
     {
       xmin: ST_XMin(geometry)::FLOAT,
       ymin: ST_YMin(geometry)::FLOAT,

--- a/sql/settlements.sql
+++ b/sql/settlements.sql
@@ -1,6 +1,6 @@
 COPY (
   WITH raw AS (
-    SELECT type, id, tags, geometry
+    SELECT type, id, tags, version, timestamp, geometry
     FROM '{{INPUT}}'
     WHERE kind = 'node'
       AND tags['place'] IN (
@@ -22,6 +22,8 @@ COPY (
     tags['wikidata']                        AS wikidata,
     tags['wikipedia']                       AS wikipedia,
     TRY_CAST(tags['population'] AS UBIGINT) AS population,
+    version,
+    timestamp,
     {
       xmin: ST_XMin(geometry)::FLOAT,
       ymin: ST_YMin(geometry)::FLOAT,

--- a/sql/waterways.sql
+++ b/sql/waterways.sql
@@ -1,6 +1,6 @@
 COPY (
   WITH raw AS (
-    SELECT type, id, tags, geometry
+    SELECT type, id, tags, version, timestamp, geometry
     FROM '{{INPUT}}'
     WHERE kind = 'line'
       AND tags['waterway'] IN ('river', 'stream', 'canal', 'ditch', 'drain', 'flowline', 'fairway', 'link')
@@ -41,6 +41,8 @@ COPY (
     tags['rapids']                   AS rapids,
     tags['rapids:name']              AS 'rapids:name',
     tags['hazard']                   AS hazard,
+    version,
+    timestamp,
     {
       xmin: ST_XMin(geometry)::FLOAT,
       ymin: ST_YMin(geometry)::FLOAT,


### PR DESCRIPTION
This bumps duckdb-osmium to v0.5, which supports reading OSM PBF metadata, so we can add `version` (the OSM element's version number) and `timestamp` (when the element was last modified) columns to Layercake layers. These are useful signals about how likely the record is to be correct and up to date.

As a side effect of bumping duckdb-osmium to v0.5, layers are now allowed to contain NULL geometries. This is permitted by the GeoParquet spec, but may be a breaking change for some workflows.

I think it's okay for Layercake to publish rows with null geometries, and expect downstream consumers to add a predicate like `WHERE geometry IS NOT NULL` when fetching data if they need to ensure that all rows have a geometry. But if anyone has opinions on this, leave a comment and let me know.